### PR TITLE
chore(deps): Unbump nyc to ^13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "firebase-admin": "^7.3.0",
     "firebase-functions": "^2.3.0",
     "firebase-functions-test": "^0.1.6",
-    "nyc": "^14.0.0",
+    "nyc": "^13.0.0",
     "prettier": "^1.17.0",
     "standard-version": "^5.0.2",
     "tslint": "^5.16.0",


### PR DESCRIPTION
Some issue with nyc@14. See https://github.com/istanbuljs/nyc/issues/1086