### PR TITLE
feat(maintainCount): Convert to single onWrite trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports.replicateMasterToDetail = integrify({
       },
 
       // Optional:
-      isCollectionGroup: true,  // Replicate into collection group, see more below
+      isCollectionGroup: true, // Replicate into collection group, see more below
     },
   ],
 
@@ -74,7 +74,7 @@ module.exports.deleteReferencesToMaster = integrify({
       foreignKey: 'masterId',
 
       // Optional:
-      isCollectionGroup: true,  // Delete from collection group, see more below
+      isCollectionGroup: true, // Delete from collection group, see more below
     },
   ],
 
@@ -88,10 +88,7 @@ module.exports.deleteReferencesToMaster = integrify({
 });
 
 // Automatically maintain count
-[
-  module.exports.incrementFavoritesCount,
-  module.exports.decrementFavoritesCount,
-] = integrify({
+module.exports.maintainFavoritesCount = integrify({
   rule: 'MAINTAIN_COUNT',
   source: {
     collection: 'favorites',

--- a/package.json
+++ b/package.json
@@ -93,27 +93,27 @@
       },
       {
         "type": "chore",
-        "section": "Other"
+        "section": "Chores"
       },
       {
         "type": "docs",
-        "section": "Other"
+        "section": "Docs"
       },
       {
         "type": "style",
-        "section": "Other"
+        "section": "Style"
       },
       {
         "type": "refactor",
-        "section": "Other"
+        "section": "Refactor"
       },
       {
         "type": "perf",
-        "section": "Other"
+        "section": "Performance"
       },
       {
         "type": "test",
-        "section": "Other"
+        "section": "Tests"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "@commitlint/config-conventional"
     ],
     "rules": {
+      "scope-case": [1, "always", "lower-case"],
       "subject-case": [2, "always", "sentence-case"]
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,10 @@ export function integrify(ruleOrConfig?: Rule | Config) {
     rules.forEach(thisRule => {
       if (
         isReplicateAttributesRule(thisRule) ||
-        isDeleteReferencesRule(thisRule)
+        isDeleteReferencesRule(thisRule) ||
+        isMaintainCountRule(thisRule)
       ) {
         functions[thisRule.name] = integrify(thisRule);
-      } else if (isMaintainCountRule(thisRule)) {
-        [
-          functions[`increment${thisRule.name}`],
-          functions[`decrement${thisRule.name}`],
-        ] = integrify(thisRule);
       } else {
         throw new Error(
           `integrify: Unknown rule: [${JSON.stringify(thisRule)}]`

--- a/test/functions/index.js
+++ b/test/functions/index.js
@@ -62,10 +62,7 @@ module.exports.deleteReferencesToMaster = integrify({
   },
 });
 
-[
-  module.exports.incrementFavoritesCount,
-  module.exports.decrementFavoritesCount,
-] = integrify({
+module.exports.maintainFavoritesCount = integrify({
   rule: 'MAINTAIN_COUNT',
   source: {
     collection: 'favorites',

--- a/test/functions/integrify.rules.js
+++ b/test/functions/integrify.rules.js
@@ -57,7 +57,7 @@ module.exports = [
   },
   {
     rule: 'MAINTAIN_COUNT',
-    name: 'FavoritesCount',
+    name: 'maintainFavoritesCount',
     source: {
       collection: 'favorites',
       foreignKey: 'articleId',


### PR DESCRIPTION
BREAKING CHANGE: MAINTAIN_COUNT rule now returns single onWrite trigger.
Previously, it used to return two triggers; onCreate and onDelete.
This should simplify usage.

Before:

```js
[
  module.exports.incrementFavoritesCount,
  module.exports.decrementFavoritesCount,
] = integrify({
  rule: 'MAINTAIN_COUNT',
  // ...
```

After:

```js
module.exports.maintainFavoritesCount = integrify({
  rule: 'MAINTAIN_COUNT',
  // ...
```